### PR TITLE
Small fix in defjump

### DIFF
--- a/jump.el
+++ b/jump.el
@@ -289,7 +289,7 @@ find the current method which defaults to `which-function'."
   `(defun ,name (&optional create)
      ,(concat doc "\n\nautomatically created by `defjump'")
      (interactive "P")
-     (let ((root ,(if (functionp root) (root) root))
+     (let ((root ,(if (functionp root) `(,root) root))
 	   (method-command ,(or method-command 'which-function))
 	   matches)
        (loop ;; try every rule in mappings


### PR DESCRIPTION
The macro expansion for the root parameter was broken. It caused rinari to fail
jumping.

Assuming I've used the new macro correctly on my rinari mods, the macro didn't detect the root of a project correctly. With this change, it looks OK.
