### PR TITLE
Wrap the main function body with `save-match-data`

### DIFF
--- a/inflections.el
+++ b/inflections.el
@@ -49,20 +49,21 @@
   "Regex matching similar to the =~ operator found in other languages."
   (let ((str (cl-gensym)))
     `(let ((,str ,string))
-       (when (string-match ,regex ,str)
-         (cl-symbol-macrolet ,(cl-loop for i to 9 collect
-                                       (let ((sym (intern (concat "$" (number-to-string i)))))
-                                         `(,sym (match-string ,i ,str))))
-           (cl-flet (($ (i) (match-string i ,str))
-                     (sub (replacement &optional (i 0) &key fixedcase literal-string)
-                          (replace-match replacement fixedcase literal-string ,str i)))
-             (cl-symbol-macrolet ( ;;before
-                                  ($b (substring ,str 0 (match-beginning 0)))
-                                  ;;match
-                                  ($m (match-string 0 ,str))
-                                  ;;after
-                                  ($a (substring ,str (match-end 0) (length ,str))))
-               ,@body)))))))
+       (save-match-data
+         (when (string-match ,regex ,str)
+           (cl-symbol-macrolet ,(cl-loop for i to 9 collect
+                                         (let ((sym (intern (concat "$" (number-to-string i)))))
+                                           `(,sym (match-string ,i ,str))))
+             (cl-flet (($ (i) (match-string i ,str))
+                       (sub (replacement &optional (i 0) &key fixedcase literal-string)
+                            (replace-match replacement fixedcase literal-string ,str i)))
+               (cl-symbol-macrolet ( ;;before
+                                    ($b (substring ,str 0 (match-beginning 0)))
+                                    ;;match
+                                    ($m (match-string 0 ,str))
+                                    ;;after
+                                    ($a (substring ,str (match-end 0) (length ,str))))
+                 ,@body))))))))
 
 (define-inflectors
   (:plural "$" "s")


### PR DESCRIPTION
Without this, inflection functions cannot be safely used when string search and replacement are involved.

```elisp
;; pluralizing the last word
(replace-regexp-in-string "[A-za-z]+\\'" #'inflection-pluralize-string "ruby on rail")
"ruby on railrails"
```